### PR TITLE
Fixes #1 (link labels and tooltip)

### DIFF
--- a/appserver/static/visualizations/flow_map_viz/src/visualization_source.js
+++ b/appserver/static/visualizations/flow_map_viz/src/visualization_source.js
@@ -291,7 +291,7 @@ function(
                     var maxx = Math.max(d.sx, d.tx);
                     var miny = Math.min(d.sy, d.ty);
                     var maxy = Math.max(d.sy, d.ty); 
-                    return "translate(" + ((maxx - minx) * 0.5 + minx) + "px," + ((maxy - miny) * 0.5 + miny - (viz.config.link_text_size * 0.3)) + "px)";
+                    return "translate(" + ((maxx - minx) * 0.5 + minx) + "px," + ((maxy - miny) * 0.5 + miny) + "px)";
                 });
         },
 
@@ -949,13 +949,19 @@ function(
                 .data(viz.linkData, function(d){ return d.id; })
                 .join("div")
                     .attr("class", "flow_map_viz-linklabel")
-                    .style("left", function(d){ return Number(d.labelx) - 100 + "px";})
-                    .style("top", function(d){ return Number(d.labely) - (viz.config.link_text_size) + "px"; })
+                    .style("left", function(d){ return Number(d.labelx) + "px";})
+                    .style("top", function(d){ return Number(d.labely) + "px"; })
                     .attr("title", function(d) { return d.tooltip; })
                     .style("text-shadow", function(d){
                         return "-1px -1px 0 " + viz.config.background_color + ", 1px -1px 0 " + viz.config.background_color + ", -1px 1px 0 " + viz.config.background_color + ", 1px 1px 0 " + viz.config.background_color;
                     })
                     .html(function(d) { return d.label; });
+
+            // Center link labels
+            document.querySelectorAll(".flow_map_viz-linklabel").forEach( function(label) {
+                label.style.left = "calc(" + label.style.left + " - " + (label.offsetWidth/2) + "px)";
+                label.style.top  = "calc(" + label.style.top + " - " + (label.offsetHeight/2) + "px)";
+            });
 
             // redo particles
             clearTimeout(viz.startParticlesTimeout);

--- a/appserver/static/visualizations/flow_map_viz/visualization.css
+++ b/appserver/static/visualizations/flow_map_viz/visualization.css
@@ -76,7 +76,6 @@
     align-items: center;
     justify-content: center;
     text-align: center;
-    width: 200px;
 }
 
 

--- a/appserver/static/visualizations/flow_map_viz/visualization.js
+++ b/appserver/static/visualizations/flow_map_viz/visualization.js
@@ -336,7 +336,7 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                    var maxx = Math.max(d.sx, d.tx);
 	                    var miny = Math.min(d.sy, d.ty);
 	                    var maxy = Math.max(d.sy, d.ty); 
-	                    return "translate(" + ((maxx - minx) * 0.5 + minx) + "px," + ((maxy - miny) * 0.5 + miny - (viz.config.link_text_size * 0.3)) + "px)";
+	                    return "translate(" + ((maxx - minx) * 0.5 + minx) + "px," + ((maxy - miny) * 0.5 + miny) + "px)";
 	                });
 	        },
 
@@ -994,13 +994,19 @@ define(["api/SplunkVisualizationBase","api/SplunkVisualizationUtils"], function(
 	                .data(viz.linkData, function(d){ return d.id; })
 	                .join("div")
 	                    .attr("class", "flow_map_viz-linklabel")
-	                    .style("left", function(d){ return Number(d.labelx) - 100 + "px";})
-	                    .style("top", function(d){ return Number(d.labely) - (viz.config.link_text_size) + "px"; })
+	                    .style("left", function(d){ return Number(d.labelx) + "px";})
+	                    .style("top", function(d){ return Number(d.labely) + "px"; })
 	                    .attr("title", function(d) { return d.tooltip; })
 	                    .style("text-shadow", function(d){
 	                        return "-1px -1px 0 " + viz.config.background_color + ", 1px -1px 0 " + viz.config.background_color + ", -1px 1px 0 " + viz.config.background_color + ", 1px 1px 0 " + viz.config.background_color;
 	                    })
 	                    .html(function(d) { return d.label; });
+
+ 	            // Center link labels
+ 	            document.querySelectorAll(".flow_map_viz-linklabel").forEach( function(label) {
+ 	                label.style.left = "calc(" + label.style.left + " - " + (label.offsetWidth/2) + "px)";
+ 	                label.style.top  = "calc(" + label.style.top + " - " + (label.offsetHeight/2) + "px)";
+ 	            });
 
 	            // redo particles
 	            clearTimeout(viz.startParticlesTimeout);


### PR DESCRIPTION
This PR will fix #1:
- Centers link labels on links
- Fixes access to tooltips when there are a lot of links next to each other

**Before the patch:**
![image](https://user-images.githubusercontent.com/1888635/75146842-3a6a1700-56fc-11ea-9fd2-8f6565fde2df.png)

**After the patch:**
![image](https://user-images.githubusercontent.com/1888635/75155407-495ac480-5710-11ea-9a8e-a48b501b2bf3.png)
